### PR TITLE
old versions of nose require older setuptools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ branches:
     - master
     - example_updates
 python:
-  - 3.5
   - 3.6
+  - 3.7
 
 # to add testing, replace PACKAGE_NAME with your package's name, and {AUTHOR_EMAILS} with a
 # YAML list of author emails, like:

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -5,3 +5,4 @@ coverage
 coveralls
 matplotlib
 scipy>=0.11
+setuptools==51.0.0


### PR DESCRIPTION
Trying to fix documentation auto build, which is now out of date:

https://readthedocs.org/projects/access/builds/15870255/

`setuptools` has moved on with its life, and dropped use2_3 in 58.0.0.