### PR TITLE
update GHA testing, etc.

### DIFF
--- a/.ci/310.yml
+++ b/.ci/310.yml
@@ -1,0 +1,22 @@
+name: access_310
+channels:
+    - conda-forge
+dependencies:
+    - python=3.10
+    - scipy>=0.11
+    - numpy>=1.3
+    - pandas>=0.23.4
+    - geopandas
+    - requests>=2
+    - matplotlib
+    - scipy>=0.11
+    - sphinx
+    - sphinxcontrib-bibtex
+    - sphinx_bootstrap_theme
+    - numpydoc
+    # testing, etc
+    - codecov
+    - pytest
+    - pytest-mpl
+    - pytest-cov
+    - twine

--- a/.ci/310.yml
+++ b/.ci/310.yml
@@ -19,4 +19,5 @@ dependencies:
     - pytest
     - pytest-mpl
     - pytest-cov
+    - pytest-xdist
     - twine

--- a/.ci/37.yml
+++ b/.ci/37.yml
@@ -2,11 +2,11 @@ name: access_37
 channels:
     - conda-forge
 dependencies:
-    - python =3.7
-    - scipy >=0.11
-    - numpy >=1.3
-    - pandas >=0.23.4
-    - requests >=2
+    - python=3.7
+    - scipy>=0.11
+    - numpy>=1.3
+    - pandas>=0.23.4
+    - requests>=2
     - geopandas
    # testing, etc
     - codecov

--- a/.ci/37.yml
+++ b/.ci/37.yml
@@ -13,4 +13,5 @@ dependencies:
     - pytest
     - pytest-mpl
     - pytest-cov
+    - pytest-xdist
     - twine

--- a/.ci/38.yml
+++ b/.ci/38.yml
@@ -13,4 +13,5 @@ dependencies:
     - pytest
     - pytest-mpl
     - pytest-cov
+    - pytest-xdist
     - twine

--- a/.ci/38.yml
+++ b/.ci/38.yml
@@ -2,11 +2,11 @@ name: access_38
 channels:
     - conda-forge
 dependencies:
-    - python =3.8
-    - scipy >=0.11
-    - numpy >=1.3
-    - pandas >=0.23.4
-    - requests >=2
+    - python=3.8
+    - scipy>=0.11
+    - numpy>=1.3
+    - pandas>=0.23.4
+    - requests>=2
     - geopandas
     # testing, etc
     - codecov

--- a/.ci/39.yml
+++ b/.ci/39.yml
@@ -2,18 +2,14 @@ name: access_39
 channels:
     - conda-forge
 dependencies:
-    - python =3.9
-    - scipy >=0.11
-    - numpy >=1.3
-    - pandas >=0.23.4
+    - python=3.9
+    - scipy>=0.11
+    - numpy>=1.3
+    - pandas>=0.23.4
     - geopandas
-    - requests >=2
+    - requests>=2
     - matplotlib
     - scipy>=0.11
-    - sphinx
-    - sphinxcontrib-bibtex
-    - sphinx_bootstrap_theme
-    - numpydoc
     # testing, etc
     - codecov
     - pytest

--- a/.ci/39.yml
+++ b/.ci/39.yml
@@ -15,4 +15,5 @@ dependencies:
     - pytest
     - pytest-mpl
     - pytest-cov
+    - pytest-xdist
     - twine

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -13,7 +13,7 @@
      strategy:
        matrix:
          os: ['ubuntu-latest']
-         environment-file: [.ci/39.yml]
+         environment-file: [.ci/310.yml]
          experimental: [false]
      steps:
        - uses: actions/checkout@v2

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -22,10 +22,10 @@
          environment-file: [.ci/37.yml, .ci/38.yml, .ci/39.yml, .ci/310.yml]
          experimental: [false]
          include:
-           - environment-file: ci/310.yml
+           - environment-file: .ci/310.yml
              experimental: false
              os: macos-latest
-           - environment-file: ci/310.yml
+           - environment-file: .ci/310.yml
              os: windows-latest
              experimental: false
          

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -20,14 +20,12 @@
        matrix:
          os: [ubuntu-latest]
          environment-file: [.ci/37.yml, .ci/38.yml, .ci/39.yml, .ci/310.yml]
-         experimental: [false]
+         experimental: false
          include:
            - environment-file: ci/310.yaml
              os: macos-latest
-             experimental: [false]
            - environment-file: ci/310.yaml
              os: windows-latest
-             experimental: [false]
          
      steps:
        - name: checkout repo

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -15,8 +15,13 @@
      timeout-minutes: 90
      strategy:
        matrix:
-         os: [ubuntu-latest, macos-latest, windows-latest]
+         os: [ubuntu-latest]
          environment-file: [.ci/37.yml, .ci/38.yml, .ci/39.yml, .ci/310.yml]
+         include:
+           - environment-file: ci/310.yaml
+             os: macos-latest
+           - environment-file: ci/310.yaml
+             os: windows-latest
          experimental: [false]
      steps:
        - name: checkout repo

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -20,12 +20,14 @@
        matrix:
          os: [ubuntu-latest]
          environment-file: [.ci/37.yml, .ci/38.yml, .ci/39.yml, .ci/310.yml]
-         experimental: false
+         experimental: [false]
          include:
            - environment-file: ci/310.yaml
+             experimental: false
              os: macos-latest
            - environment-file: ci/310.yaml
              os: windows-latest
+             experimental: false
          
      steps:
        - name: checkout repo

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -10,6 +10,9 @@
  jobs:
    unittests:
      name: CI (${{ matrix.os }}-${{ matrix.environment-file }})
+     env:
+       INSTALL: pip install -e . --no-deps --force-reinstall
+       RUN_TEST: pytest -v -n auto access --cov access --cov-report xml --color yes --cov-append --cov-report term-missing
      runs-on: ${{ matrix.os }}
      continue-on-error: ${{ matrix.experimental }}
      timeout-minutes: 90
@@ -35,22 +38,22 @@
         
        - name: reinstall access - bash
          shell: bash -l {0}
-         run: pip install -e . --no-deps --force-reinstall
+         run: ${{ env.INSTALL }}
          if: matrix.os != 'windows-latest'
       
        - name: reinstall access - powershell
          shell: powershell
-         run: pip install -e . --no-deps --force-reinstall
+         run: ${{ env.INSTALL }}
          if: matrix.os == 'windows-latest'
        
        - name: run pytest - bash
          shell: bash -l {0}
-         run: pytest -v access --cov=access --cov-report=xml
+         run: ${{ env.RUN_TEST }}
          if: matrix.os != 'windows-latest'
        
        - name: run pytest - powershell
          shell: powershell
-         run: pytest -v access --cov=access --cov-report=xml
+         run: ${{ env.RUN_TEST }}
          if: matrix.os == 'windows-latest'
        
        - name: codecov

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -11,7 +11,7 @@
    unittests:
      name: CI (${{ matrix.os }}-${{ matrix.environment-file }})
      env:
-       INSTALL: pip install -e .
+       INSTALL: pip install -e . 
        RUN_TEST: pytest -v -n auto access --cov access --cov-report xml --color yes --cov-append --cov-report term-missing
      runs-on: ${{ matrix.os }}
      continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -22,10 +22,10 @@
          environment-file: [.ci/37.yml, .ci/38.yml, .ci/39.yml, .ci/310.yml]
          experimental: [false]
          include:
-           - environment-file: ci/310.yaml
+           - environment-file: ci/310.yml
              experimental: false
              os: macos-latest
-           - environment-file: ci/310.yaml
+           - environment-file: ci/310.yml
              os: windows-latest
              experimental: false
          

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -11,7 +11,7 @@
    unittests:
      name: CI (${{ matrix.os }}-${{ matrix.environment-file }})
      env:
-       INSTALL: pip install -e . --no-deps --force-reinstall
+       INSTALL: pip install -e .
        RUN_TEST: pytest -v -n auto access --cov access --cov-report xml --color yes --cov-append --cov-report term-missing
      runs-on: ${{ matrix.os }}
      continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -20,12 +20,15 @@
        matrix:
          os: [ubuntu-latest]
          environment-file: [.ci/37.yml, .ci/38.yml, .ci/39.yml, .ci/310.yml]
+         experimental: [false]
          include:
            - environment-file: ci/310.yaml
              os: macos-latest
+             experimental: [false]
            - environment-file: ci/310.yaml
              os: windows-latest
-         experimental: [false]
+             experimental: [false]
+         
      steps:
        - name: checkout repo
          uses: actions/checkout@v2

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -16,7 +16,7 @@
      strategy:
        matrix:
          os: [ubuntu-latest, macos-latest, windows-latest]
-         environment-file: [.ci/37.yml, .ci/38.yml, .ci/39.yml]
+         environment-file: [.ci/37.yml, .ci/38.yml, .ci/39.yml, .ci/310.yml]
          experimental: [false]
      steps:
        - name: checkout repo

--- a/environment.yml
+++ b/environment.yml
@@ -2,8 +2,9 @@ name: access
 channels:
     - conda-forge
 dependencies:
-    - python >=3.5
-    - scipy >=0.11
-    - numpy >=1.3
-    - pandas >=0.23.4
-    - requests >=2
+    - python>=3.7
+    - geopandas
+    - numpy>=1.3
+    - pandas>=0.23.4
+    - scipy>=0.11
+    - requests>=2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
+geopandas
 numpy>=1.3
 pandas>=0.23.4
-requests >=2
-geopandas
+requests>=2

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,7 +1,8 @@
-nose
-nose-progressive
-nose-exclude
 coverage
 coveralls
 matplotlib
+pytest
+pytest-cov
+pytest-mpl
+pytest-xdist
 scipy>=0.11


### PR DESCRIPTION
This PR performs the following maintenance task:
* adds Python 3.10 to the testing matrix
* trims down macOS & Windows test to only Python 3.10 (we need to be responsible service users 😅)
* add global variables to CI for install and pytest runs
* add multicore testing functionality with pytest
* cleans up CI environments and requirements* files
* moves doc builds to Python 3.10