### PR TITLE
REF: load datasets from the URL on request

### DIFF
--- a/access/datasets.py
+++ b/access/datasets.py
@@ -5,63 +5,37 @@ import pandas as pd
 
 
 class Datasets(object):
-    _dir = 'chi_med_data'
-
-    _homedir = os.path.expanduser("~")
-    _dir_path = os.path.join(_homedir, _dir)
-
-    _bucket_url = 'https://uchicago-csds-access.s3.amazonaws.com/ex_datasets'
-
-    _datasets = {'chi_times': 'chicago_metro_times.csv.bz2',
-                 'chi_doc': 'chicago_metro_docs_dentists.csv',
-                 'chi_pop': 'chicago_metro_pop.csv',
-                 'chi_doc_geom': 'chicago_metro_docs_dentists.geojson',
-                 'chi_pop_geom': 'chicago_metro_pop.geojson',
-                 'chi_euclidean': 'chicago_metro_euclidean_costs.csv.bz2',
-                 'chi_euclidean_neighbors': 'chicago_metro_euclidean_cost_neighbors.csv.bz2',
-                 'cook_county_hospitals': 'cook_county_hospitals.csv',
-                 'cook_county_hospitals_geom': 'hospitals_cookcty.geojson',
-                 'cook_county_tracts': 'cook_county_tracts.geojson'}
-
-
     @staticmethod
     def load_data(key):
         """
         Return path for available datasets.
         """
-        if not os.path.exists(Datasets._dir_path):
-            os.mkdir(Datasets._dir_path)
-            print('Creating directory chi_med_data...')
 
-        if key not in Datasets._datasets.keys():
-            print('{key} not an available dataset. Use Datasets.available_datasets to see the available datasets.'.format(key=key))
+        _datasets = {
+            "chi_times": "chicago_metro_times.csv.bz2",
+            "chi_doc": "chicago_metro_docs_dentists.csv",
+            "chi_pop": "chicago_metro_pop.csv",
+            "chi_doc_geom": "chicago_metro_docs_dentists.geojson",
+            "chi_pop_geom": "chicago_metro_pop.geojson",
+            "chi_euclidean": "chicago_metro_euclidean_costs.csv.bz2",
+            "chi_euclidean_neighbors": "chicago_metro_euclidean_cost_neighbors.csv.bz2",
+            "cook_county_hospitals": "cook_county_hospitals.csv",
+            "cook_county_hospitals_geom": "hospitals_cookcty.geojson",
+            "cook_county_tracts": "cook_county_tracts.geojson",
+        }
 
+        url = f"https://uchicago-csds-access.s3.amazonaws.com/ex_datasets/{_datasets[key]}"
 
-        else:
+        if ".geojson" in url:
+            import geopandas as gpd
 
-            path = os.path.join(Datasets._dir_path, Datasets._datasets[key])
+            return gpd.read_file(url)
 
-            if key in Datasets._datasets.keys() and not os.path.exists(path):
-                print('Downloading {key} to {path}...'.format(key = key, path = Datasets._dir_path))
-                req = requests.get(os.path.join(Datasets._bucket_url, Datasets._datasets[key]))
-                file_path = os.path.join(Datasets._dir_path, Datasets._datasets[key])
-
-                with open(file_path, 'wb') as f:
-                    f.write(req.content)
-                print('Download complete.')
-
-            if '.geojson' in path:
-                import geopandas as gpd
-
-                return gpd.read_file(path)
-
-
-            return pd.read_csv(path)
-
+        return pd.read_csv(url)
 
     @staticmethod
     def available_datasets():
-        desc =  '''
+        desc = """
 chi_times: Cost matrix with travel times from each Chicago Census Tract to all others.\n
 chi_doc: Doctor and dentist counts for each Chicago Census Tract.\n
 chi_pop: Population counts for each Chicago Census Tract.\n
@@ -72,5 +46,5 @@ chi_euclidean_neighbors: Euclidean distance cost matrix with distances from each
 cook_county_hospitals: Contains data for each hospital location in Cook County including X Y coordinates.\n
 cook_county_hospitals_geom: Contains data for each hospital location in Cook County including X Y coordinates, and geometric points for each hospital.\n
 cook_county_tracts: Geometric representation of each Census Tract in Cook County.
-        '''
+        """
         print(desc)

--- a/access/tests/test_datasets.py
+++ b/access/tests/test_datasets.py
@@ -1,38 +1,18 @@
-import os
-import sys
-sys.path.append('../..')
-
-import math
 import unittest
 
-import numpy as np
 import pandas as pd
 import geopandas as gpd
 from access.datasets import Datasets
-import util as tu
 
 
 class TestDatasets(unittest.TestCase):
-
-    def test_file_download(self):
-        file_name = 'chi_times'
-        file_path = os.path.join(Datasets._dir_path, Datasets._datasets[file_name])
-        if os.path.exists(file_path):
-            os.remove(file_path)
-
-        Datasets.load_data(file_name)
-
-        actual = os.path.exists(file_path)
-
-        self.assertEqual(actual, True)
-
-
     def test_load_geopandas_dataset(self):
-        result = Datasets.load_data('chi_doc_geom')
-        actual = type(result) == gpd.geodataframe.GeoDataFrame
+        result = Datasets.load_data("chi_doc_geom")
+        assert isinstance(result, gpd.GeoDataFrame)
 
-        self.assertEqual(actual, True)
-
+    def test_load_pandas_dataset(self):
+        result = Datasets.load_data("chi_times")
+        assert isinstance(result, pd.DataFrame)
 
     def test_prints_available_datasets(self):
         Datasets.available_datasets()


### PR DESCRIPTION
xref #23

Removing caching of datasets and loading them directly from the S3 bucket on `load_data`. These are used only in examples and there's no reason to dump them to the disk.