### PR TITLE
Partial solution to #18

### DIFF
--- a/access/fca.py
+++ b/access/fca.py
@@ -318,9 +318,9 @@ def three_stage_fca(demand_df, supply_df, cost_df, max_cost,
 
     #sum, into a series, the supply to total demand ratios for each location
     three_stage_fca_series = weighted_catchment(supply_to_total_demand_frame, cost_df.sort_index(), max_cost,
-                                          cost_source = cost_dest, cost_dest = cost_origin, cost_cost = cost_name,
-                                          loc_index = 'geoid', loc_value = "Rl",
-                                          weight_fn = weight_fn, three_stage_weight = True)
+                                                cost_source = cost_dest, cost_dest = cost_origin, cost_cost = cost_name,
+                                                loc_index = 'geoid', loc_value = "Rl",
+                                                weight_fn = weight_fn, three_stage_weight = True)
 
     #remove the preference weight G from the original costs dataframe
     cost_df.drop(columns = ["G", "W3", "W3sum"], inplace = True)

--- a/access/fca.py
+++ b/access/fca.py
@@ -303,17 +303,17 @@ def three_stage_fca(demand_df, supply_df, cost_df, max_cost,
                                           weight_fn = weight_fn, three_stage_weight = True)
 
     #create a temporary dataframe, temp, that holds the supply and aggregate demand at each location
-    temp = supply_df.join(total_demand_series, how = 'right', rsuffix = 'r')
+    temp = supply_df.join(total_demand_series, how = 'right', rsuffix = '_W')
 
     #there may be NA values due to a shorter supply dataframe than the demand dataframe.
     #in this case, replace any potential NA values(which correspond to supply locations with no supply) with 0.
     temp[supply_name].fillna(0, inplace = True)
 
     #calculate the fractional ratio of supply to aggregate demand at each location, or Rl
-    temp['Rl'] = temp[supply_name] / temp[demand_name]
+    temp['Rl'] = temp[supply_name] / temp[demand_name + "_W"]
 
     #separate the fractional ratio of supply to aggregate demand at each location, or Rl, into a new dataframe
-    supply_to_total_demand_frame = pd.DataFrame(data = {'Rl':temp['Rl']})
+    supply_to_total_demand_frame = pd.DataFrame(data = {'Rl' : temp['Rl']})
     supply_to_total_demand_frame.index.name = 'geoid'
 
     #sum, into a series, the supply to total demand ratios for each location

--- a/access/tests/test_euclidean.py
+++ b/access/tests/test_euclidean.py
@@ -81,7 +81,7 @@ class TestEuclidean(unittest.TestCase):
 
         actual = hasattr(self.model, '_default_cost')
 
-        self.assertEquals(actual, True)
+        self.assertEqual(actual, True)
 
 
 class TestEuclideanNeighbors(unittest.TestCase):
@@ -144,4 +144,4 @@ class TestEuclideanNeighbors(unittest.TestCase):
 
         actual = hasattr(self.model, '_neighbor_default_cost')
 
-        self.assertEquals(actual, True)
+        self.assertEqual(actual, True)

--- a/access/tests/test_floating_catchment_area.py
+++ b/access/tests/test_floating_catchment_area.py
@@ -45,7 +45,7 @@ class TestFloatingCatchmentArea(unittest.TestCase):
         result = self.model.fca_ratio(max_cost = small_catchment)
         actual = self.model.access_df.iloc[0]['fca_value']
 
-        self.assertEqual(actual, 1)
+        self.assertTrue((1 == self.model.access_df['fca_value']).all())
 
 
     def test_floating_catchment_area_ratio_large_catchment_normalized(self):
@@ -84,7 +84,7 @@ class TestFloatingCatchmentArea(unittest.TestCase):
         result = self.model.two_stage_fca()
         actual = self.model.access_df.iloc[0]['2sfca_value']
 
-        self.assertEqual(actual, 25)
+        self.assertEqual(actual, 5)
 
 
     def test_two_stage_floating_catchment_area_small_catchment(self):
@@ -124,7 +124,7 @@ class TestFloatingCatchmentArea(unittest.TestCase):
         result = self.model.two_stage_fca(supply_values = 'value')
         actual = self.model.access_df.iloc[0]['2sfca_value']
 
-        self.assertEqual(actual, 25)
+        self.assertEqual(actual, 5)
 
 
     def test_two_stage_floating_catchment_area_run_again_and_test_overwrite(self):
@@ -132,7 +132,7 @@ class TestFloatingCatchmentArea(unittest.TestCase):
         result = self.model.two_stage_fca()
         actual = self.model.access_df.iloc[0]['2sfca_value']
 
-        self.assertEqual(actual, 25)
+        self.assertEqual(actual, 5)
 
 
     def test_two_stage_floating_catchment_area_large_catchment_normalize(self):
@@ -140,7 +140,7 @@ class TestFloatingCatchmentArea(unittest.TestCase):
 
         actual = self.model.access_df.iloc[0]['2sfca_value']
 
-        self.assertEqual(actual, 25)
+        self.assertEqual(actual, 5)
 
 
     def test_three_stage_floating_catchment_area_large_catchment(self):
@@ -148,7 +148,7 @@ class TestFloatingCatchmentArea(unittest.TestCase):
         result = self.model.three_stage_fca(weight_fn = wfn)
         actual = self.model.access_df.iloc[0]['3sfca_value']
 
-        self.assertEqual(actual, 25)
+        self.assertEqual(actual, 5)
 
 
     def test_three_stage_floating_catchment_area_large_catchment_run_again_and_test_overwrite(self):
@@ -157,7 +157,7 @@ class TestFloatingCatchmentArea(unittest.TestCase):
         result = self.model.three_stage_fca(weight_fn = wfn)
         actual = self.model.access_df.iloc[0]['3sfca_value']
 
-        self.assertEqual(actual, 25)
+        self.assertEqual(actual, 5)
 
 
     def test_three_stage_floating_catchment_area_large_catchment_normalize(self):
@@ -165,7 +165,7 @@ class TestFloatingCatchmentArea(unittest.TestCase):
         result = self.model.three_stage_fca(weight_fn = wfn, normalize = True)
         actual = self.model.access_df.iloc[0]['3sfca_value']
 
-        self.assertEqual(actual, 25)
+        self.assertEqual(actual, 5)
 
 
     def test_three_stage_floating_catchment_area_small_catchment(self):
@@ -190,7 +190,7 @@ class TestFloatingCatchmentArea(unittest.TestCase):
         result = self.model.enhanced_two_stage_fca()
         actual = self.model.access_df.iloc[0]['e2sfca_value']
 
-        self.assertEqual(actual, 25)
+        self.assertEqual(actual, 5)
 
 
     def test_enhanced_two_stage_floating_catchment_area_small_catchment(self):

--- a/access/tests/test_hospital_example.py
+++ b/access/tests/test_hospital_example.py
@@ -34,7 +34,7 @@ def simple_2sfca(OD, supply, demand, locs, max_travel = 61, three_stage = False)
         W = 1 / OD
 
         WS = W.sum(axis = 0)       # Sum over destinations / within columns.
-        G = W.divide(WS, axis = 1) # Sum 
+        G = W.divide(WS, axis = 1) # Divide columns by their sums.
 
         GOD = OD / G
 

--- a/access/tests/test_hospital_example.py
+++ b/access/tests/test_hospital_example.py
@@ -1,0 +1,268 @@
+import sys
+sys.path.append('../..')
+
+import math
+import unittest
+
+import numpy as np
+import pandas as pd
+import geopandas as gpd
+from access import Access, weights
+import util as tu
+
+
+def simple_2sfca(OD, supply, demand, locs, max_travel = 61):
+    """
+    Base python implementation / sanity check of 2SFCA results.
+
+    Assumes gravity weights with power of -1
+
+    Params:
+        OD (pd.DataFrame): origin/destination matrix with origin columns and destinations on index.
+        supply (Dict[int,int]): amount of supply at each location
+        demand (Dict[int,int]): amount of demand at each location
+        locs (List[int]): list of locations.
+
+    Returns:
+        Dict[int, float]: access per location
+        
+    """
+
+    D = {hosp : sum(demand[res] / OD[res][hosp]
+                    for res in locs
+                    if OD[res][hosp] < max_travel)
+         for hosp in locs}
+
+    R = {l : supply[l] / D[l] for l in locs}
+
+    A = {res : sum(R[hosp] / OD[res][hosp]
+                   for hosp in locs
+                    if OD[res][hosp] < max_travel)
+         for res in locs}
+
+    return A
+
+
+class TestHospitalExample(unittest.TestCase):
+
+    def setUp(self):
+        
+        tracts = pd.DataFrame([
+            {"geoid": 1, "pop": 100, "doc": 15},
+            {"geoid": 2, "pop": 50, "doc": 20},
+            {"geoid": 3, "pop": 10, "doc": 100},
+        ])
+        
+        self.costs = []
+        
+        # Scenario 0 is gridlock
+        # Gridlock. travel is congested in both directions
+        self.costs.append(
+        	pd.DataFrame([
+            	# Self
+            	{"origin": 1, "dest": 1, "cost": 1},
+            	{"origin": 2, "dest": 2, "cost": 1},
+            	{"origin": 3, "dest": 3, "cost": 1},
+            	
+            	# Inbound
+            	{"origin": 1, "dest": 3, "cost": 40},
+            	{"origin": 2, "dest": 3, "cost": 40},
+            	
+            	# Outbound
+            	{"origin": 3, "dest": 1, "cost": 40},
+            	{"origin": 3, "dest": 2, "cost": 40},
+            	
+            	# Cross-city
+            	{"origin": 1, "dest": 2, "cost": 80},
+            	{"origin": 2, "dest": 1, "cost": 80}, 
+        	])
+        )
+        
+        # Scenario 1 is faster treavel to the city
+        # Commuter toll lane into the city  (similar dynamics to PM peak)
+        self.costs.append(
+          	pd.DataFrame([
+            	# Self
+            	{"origin": 1, "dest": 1, "cost": 1},
+            	{"origin": 2, "dest": 2, "cost": 1},
+            	{"origin": 3, "dest": 3, "cost": 1},
+            	
+            	# Inbound -- faster
+            	{"origin": 1, "dest": 3, "cost": 20},
+            	{"origin": 2, "dest": 3, "cost": 20},
+            	
+            	# Outbound
+            	{"origin": 3, "dest": 1, "cost": 40},
+            	{"origin": 3, "dest": 2, "cost": 40},
+            	
+            	# Cross-city -- should also 40 + 20, but leaving...
+            	{"origin": 1, "dest": 2, "cost": 80},
+            	{"origin": 2, "dest": 1, "cost": 80}, 
+        	])
+        )
+        
+        # Scenario 2 is faster travel out of the city
+        # Commuter toll lane out of the city  (similar dynamics to AM peak)
+        self.costs.append(
+        	pd.DataFrame([
+        	    # Self
+        	    {"origin": 1, "dest": 1, "cost": 1},
+        	    {"origin": 2, "dest": 2, "cost": 1},
+        	    {"origin": 3, "dest": 3, "cost": 1},
+        	    
+        	    # Inbound
+        	    {"origin": 1, "dest": 3, "cost": 40},
+        	    {"origin": 2, "dest": 3, "cost": 40},
+        	    
+        	    # Outbound - faster
+        	    {"origin": 3, "dest": 1, "cost": 20},
+        	    {"origin": 3, "dest": 2, "cost": 20},
+        	    
+        	    # Cross-city - should also be 40 + 20.
+        	    {"origin": 1, "dest": 2, "cost": 80},
+        	    {"origin": 2, "dest": 1, "cost": 80}, 
+        	])
+        )
+        
+        # Scenario 3 is symmetric, but faster travel.
+        # Commuter toll lane out of the city (similar dynamics to AM peak)
+        self.costs.append(
+        	pd.DataFrame([
+            	# Self
+            	{"origin": 1, "dest": 1, "cost": 1},
+            	{"origin": 2, "dest": 2, "cost": 1},
+            	{"origin": 3, "dest": 3, "cost": 1},
+            	
+            	# Inbound
+            	{"origin": 1, "dest": 3, "cost": 20},
+            	{"origin": 2, "dest": 3, "cost": 20},
+            	
+            	# Outbound - faster
+            	{"origin": 3, "dest": 1, "cost": 20},
+            	{"origin": 3, "dest": 2, "cost": 20},
+            	
+            	# Cross-city -- twice each half...
+            	{"origin": 1, "dest": 2, "cost": 40},
+            	{"origin": 2, "dest": 1, "cost": 40}, 
+        	])
+        )
+        
+        # input parameters fixed across scenarios
+        # Neighbor cost not used; supressed to avoid confusion.
+        params = dict(
+            demand_df = tracts, demand_index = "geoid", demand_value = "pop",
+            supply_df = tracts, supply_index = "geoid", supply_value = "doc",
+            cost_origin = "origin", cost_dest = "dest", cost_name = "cost",
+        )
+                
+        # Dictionaries for simple version.
+        locs = [1, 2, 3]
+        pops = tracts.set_index("geoid")["pop"].to_dict()
+        docs = tracts.set_index("geoid")["doc"].to_dict()
+        
+
+        # Instantiate the objects and run access.
+        self.access_scenarios = {}
+        self.reference_model  = {}
+        for n, costs in enumerate(self.costs):
+            self.access_scenarios[n] = Access(**params, cost_df = costs)
+            self.access_scenarios[n].two_stage_fca(name = f"s{n}", weight_fn = weights.gravity(1, -1), max_cost = 61)
+            
+            OD = costs.pivot_table(index = "origin", columns = "dest", values = "cost").T
+            self.reference_model[n] = simple_2sfca(OD, docs, pops, locs)
+    	
+
+
+    def test_simple_2sfca_scenario_0(self):
+
+        s = 0
+
+        access_dict = self.access_scenarios[s].access_df[f"s{s}_doc"].to_dict()
+        simple_dict = self.reference_model[s]
+
+        self.assertAlmostEqual(access_dict[1], simple_dict[1])
+        self.assertAlmostEqual(access_dict[2], simple_dict[2])
+        self.assertAlmostEqual(access_dict[3], simple_dict[3])
+
+    def test_simple_2sfca_scenario_1(self):
+
+        s = 1
+
+        access_dict = self.access_scenarios[s].access_df[f"s{s}_doc"].to_dict()
+        simple_dict = self.reference_model[s]
+
+        self.assertAlmostEqual(access_dict[1], simple_dict[1])
+        self.assertAlmostEqual(access_dict[2], simple_dict[2])
+        self.assertAlmostEqual(access_dict[3], simple_dict[3])
+            
+
+    def test_simple_2sfca_scenario_2(self):
+
+        s = 2
+
+        access_dict = self.access_scenarios[s].access_df[f"s{s}_doc"].to_dict()
+        simple_dict = self.reference_model[s]
+
+        self.assertAlmostEqual(access_dict[1], simple_dict[1])
+        self.assertAlmostEqual(access_dict[2], simple_dict[2])
+        self.assertAlmostEqual(access_dict[3], simple_dict[3])
+            
+
+    def test_simple_2sfca_scenario_3(self):
+
+        s = 3
+
+        access_dict = self.access_scenarios[s].access_df[f"s{s}_doc"].to_dict()
+        simple_dict = self.reference_model[s]
+
+        self.assertAlmostEqual(access_dict[1], simple_dict[1])
+        self.assertAlmostEqual(access_dict[2], simple_dict[2])
+        self.assertAlmostEqual(access_dict[3], simple_dict[3])
+
+    def test_scenario_0_v_1(self):
+
+        v0 = self.access_scenarios[0].access_df[f"s0_doc"].to_dict()
+        v1 = self.access_scenarios[1].access_df[f"s1_doc"].to_dict()
+
+        # access at 1 should increase. Supply at 3 is more pertinent / lower cost since people can get there faster.
+        self.assertTrue(v1[1] > v0[1])
+
+        # access at 2 should increase. Same reasoning as above.
+        self.assertTrue(v1[2] > v0[2])
+
+        # access at 3 should decrease. More patients from 1 and 2 means greater demands on 3's doctors.
+        self.assertTrue(v1[3] < v0[3])
+    
+
+    def test_scenario_0_v_2(self):
+
+        v0 = self.access_scenarios[0].access_df[f"s0_doc"].to_dict()
+        v2 = self.access_scenarios[2].access_df[f"s2_doc"].to_dict()
+
+        # access at 1 should decrease. There is more demand coming from 3 since people can come from there faster
+        self.assertTrue(v2[1] < v0[1])
+
+        # access at 2 should decrease. There is more demand coming from 3 since people can come from there faster
+        self.assertTrue(v2[2] < v0[2])
+
+        # access at 3 should increase. There is more supply available from 1,2 since people can get there faster
+        self.assertTrue(v2[3] > v0[3])
+
+
+    def test_scenario_0_v_2(self):
+
+        v0 = self.access_scenarios[0].access_df[f"s0_doc"].to_dict()
+        v3 = self.access_scenarios[3].access_df[f"s3_doc"].to_dict()
+
+        # access at 1 should increase. It is easier to use the place with more docs.
+        self.assertTrue(v3[1] > v0[1])
+
+        # access at 2 should increase. Same reasoning as for 1.
+        self.assertTrue(v3[2] > v0[2])
+
+        # access at 3 should decrease. Same but in reverse -- suburbanites are using "urban" supply.
+        self.assertTrue(v3[3] < v0[3])
+    
+    
+            
+

--- a/access/tests/test_hospital_example.py
+++ b/access/tests/test_hospital_example.py
@@ -163,10 +163,13 @@ class TestHospitalExample(unittest.TestCase):
 
         # Instantiate the objects and run access.
         self.access_scenarios = {}
+        self.access_values    = {}
         self.reference_model  = {}
+
         for n, costs in enumerate(self.costs):
             self.access_scenarios[n] = Access(**params, cost_df = costs)
             self.access_scenarios[n].two_stage_fca(name = f"s{n}", weight_fn = weights.gravity(1, -1), max_cost = 61)
+            self.access_values[n] = self.access_scenarios[n].access_df[f"s{n}_doc"].to_dict()
             
             OD = costs.pivot_table(index = "origin", columns = "dest", values = "cost").T
             self.reference_model[n] = simple_2sfca(OD, docs, pops, locs)
@@ -221,48 +224,36 @@ class TestHospitalExample(unittest.TestCase):
 
     def test_scenario_0_v_1(self):
 
-        v0 = self.access_scenarios[0].access_df[f"s0_doc"].to_dict()
-        v1 = self.access_scenarios[1].access_df[f"s1_doc"].to_dict()
-
         # access at 1 should increase. Supply at 3 is more pertinent / lower cost since people can get there faster.
-        self.assertTrue(v1[1] > v0[1])
+        self.assertTrue(self.access_values[1][1] > self.access_values[0][1])
 
         # access at 2 should increase. Same reasoning as above.
-        self.assertTrue(v1[2] > v0[2])
+        self.assertTrue(self.access_values[1][2] > self.access_values[0][2])
 
         # access at 3 should decrease. More patients from 1 and 2 means greater demands on 3's doctors.
-        self.assertTrue(v1[3] < v0[3])
+        self.assertTrue(self.access_values[1][3] < self.access_values[0][3])
     
-
     def test_scenario_0_v_2(self):
-
-        v0 = self.access_scenarios[0].access_df[f"s0_doc"].to_dict()
-        v2 = self.access_scenarios[2].access_df[f"s2_doc"].to_dict()
 
         # access at 1 should decrease. There is more demand coming from 3 since people can come from there faster
-        self.assertTrue(v2[1] < v0[1])
+        self.assertTrue(self.access_values[2][1] < self.access_values[0][1])
 
         # access at 2 should decrease. There is more demand coming from 3 since people can come from there faster
-        self.assertTrue(v2[2] < v0[2])
+        self.assertTrue(self.access_values[2][2] < self.access_values[0][2])
 
         # access at 3 should increase. There is more supply available from 1,2 since people can get there faster
-        self.assertTrue(v2[3] > v0[3])
+        self.assertTrue(self.access_values[2][3] > self.access_values[0][3])
 
 
-    def test_scenario_0_v_2(self):
-
-        v0 = self.access_scenarios[0].access_df[f"s0_doc"].to_dict()
-        v3 = self.access_scenarios[3].access_df[f"s3_doc"].to_dict()
+    def test_scenario_0_v_3(self):
 
         # access at 1 should increase. It is easier to use the place with more docs.
-        self.assertTrue(v3[1] > v0[1])
+        self.assertTrue(self.access_values[3][1] > self.access_values[0][1])
 
         # access at 2 should increase. Same reasoning as for 1.
-        self.assertTrue(v3[2] > v0[2])
+        self.assertTrue(self.access_values[3][2] > self.access_values[0][2])
 
         # access at 3 should decrease. Same but in reverse -- suburbanites are using "urban" supply.
-        self.assertTrue(v3[3] < v0[3])
+        self.assertTrue(self.access_values[3][3] < self.access_values[0][3])
     
     
-            
-


### PR DESCRIPTION
This solves the issue noted by @knaaptime in #18, in his notebook, that the two-stage numbers were not affected by changes in the OD matrix.  (Thanks!)

This fixes a bug where it was not the weighted values that were getting summed in the two-stage calculation!  This was basically a one-line bug, that the suffix "r" [had been added](https://github.com/pysal/access/blob/bfae8edbbcb304e67884a3b1cbf292cc410fa380/access/fca.py#L224), but then not used.

I wrote a completely "base python" gravity-based 2SFCA below, that we could add as an additional unit test.'  With that fix, the package and the function below (for the four simple cases!!) agree, point-identical.  

https://gist.github.com/4a3c3d1c571523db43785e43b256ba78

See if this looks reasonable?

```
def simple_2sfca(OD, supply = docs, demand = pops, locs = locs, max_travel = 61,
                 return_debug = False):
    
    D = {hosp : sum(demand[res] / OD[res][hosp]
                    for res in locs 
                    if OD[res][hosp] < max_travel)
         for hosp in locs}

    R = {l : supply[l] / D[l] for l in locs}
    
    A = {res : sum(R[hosp] / OD[res][hosp] 
                   for hosp in locs
                    if OD[res][hosp] < max_travel)
         for res in locs}
    
    if return_debug:
        return A, R, D
    
    return A
```