### PR TITLE
update gitcount tool for access

### DIFF
--- a/tools/gitcount.ipynb
+++ b/tools/gitcount.ipynb
@@ -21,13 +21,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:16:37.950061Z",
+     "start_time": "2022-05-17T23:16:37.945680Z"
+    }
+   },
    "outputs": [],
    "source": [
-    "package_name = 'libpysal'\n",
-    "release_date = '2018-08-22'\n",
-    "start_date = '2018-07-15'"
+    "package_name = 'access'\n",
+    "release_date = '2022-05-17'\n",
+    "start_date = '2021-01-31'"
    ]
   },
   {
@@ -39,8 +44,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:16:45.956074Z",
+     "start_time": "2022-05-17T23:16:39.013043Z"
+    }
+   },
    "outputs": [],
    "source": [
     "from __future__ import print_function\n",
@@ -61,13 +71,18 @@
     "import ssl\n",
     "import yaml\n",
     "\n",
-    "context = ssl._create_unverified_context()\n"
+    "context = ssl._create_unverified_context()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:16:47.446444Z",
+     "start_time": "2022-05-17T23:16:47.442015Z"
+    }
+   },
    "outputs": [],
    "source": [
     "CWD = os.path.abspath(os.path.curdir)"
@@ -75,40 +90,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'/home/serge/Dropbox/p/pysal/src/subpackages/libpysal/tools'"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:16:47.874890Z",
+     "start_time": "2022-05-17T23:16:47.861946Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "CWD"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "datetime.datetime(2018, 7, 15, 0, 0)"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:16:49.205118Z",
+     "start_time": "2022-05-17T23:16:49.197387Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "since_date = '--since=\"{start}\"'.format(start=start_date)\n",
     "since_date\n",
@@ -118,8 +121,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:16:50.157499Z",
+     "start_time": "2022-05-17T23:16:50.151692Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# get __version__\n",
@@ -139,8 +147,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:16:52.267977Z",
+     "start_time": "2022-05-17T23:16:52.216778Z"
+    }
+   },
    "outputs": [],
    "source": [
     "cmd = ['git', 'log', '--oneline', since_date]\n",
@@ -149,20 +162,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "61"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:16:52.723059Z",
+     "start_time": "2022-05-17T23:16:52.715679Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "ncommits"
    ]
@@ -183,8 +190,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:16:55.078324Z",
+     "start_time": "2022-05-17T23:16:55.069649Z"
+    }
+   },
    "outputs": [],
    "source": [
     "identities = {'Levi John Wolf': ('ljwolf', 'Levi John Wolf'),\n",
@@ -206,8 +218,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:16:55.809853Z",
+     "start_time": "2022-05-17T23:16:55.805239Z"
+    }
+   },
    "outputs": [],
    "source": [
     "author_cmd = ['git', 'log', '--format=* %aN', since_date]"
@@ -215,8 +232,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:16:56.218962Z",
+     "start_time": "2022-05-17T23:16:56.214396Z"
+    }
+   },
    "outputs": [],
    "source": [
     "from collections import Counter"
@@ -224,8 +246,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:16:56.981077Z",
+     "start_time": "2022-05-17T23:16:56.928758Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -239,8 +266,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:16:57.345278Z",
+     "start_time": "2022-05-17T23:16:57.341476Z"
+    }
+   },
    "outputs": [],
    "source": [
     "unique_authors = counter.keys()"
@@ -248,20 +280,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "dict_keys(['Serge Rey', 'Levi John Wolf', 'Wei Kang', 'James Gaboardi', 'Eli Knaap'])"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:16:57.774890Z",
+     "start_time": "2022-05-17T23:16:57.768056Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "unique_authors"
    ]
@@ -275,8 +301,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:16:58.518333Z",
+     "start_time": "2022-05-17T23:16:58.512723Z"
+    }
+   },
    "outputs": [],
    "source": [
     "from datetime import datetime, timedelta\n",
@@ -288,8 +319,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:17:02.752602Z",
+     "start_time": "2022-05-17T23:17:02.734645Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -384,8 +420,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:17:04.371021Z",
+     "start_time": "2022-05-17T23:17:03.295584Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -404,8 +445,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:17:06.696427Z",
+     "start_time": "2022-05-17T23:17:06.690112Z"
+    }
+   },
    "outputs": [],
    "source": [
     "issue_listing = []\n",
@@ -416,8 +462,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:17:07.146998Z",
+     "start_time": "2022-05-17T23:17:07.141778Z"
+    }
+   },
    "outputs": [],
    "source": [
     "pull_listing = []\n",
@@ -428,45 +479,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['Lower case module names (#98)',\n",
-       " 'remove function regime_weights (#96)',\n",
-       " 'Ensure consistency in `from .module import *` in components of libpysal (#95)',\n",
-       " '[WIP] cleanup (#88)',\n",
-       " 'docstrings for attributes are defined in properties (#87)',\n",
-       " 'version name as __version__ (#92)',\n",
-       " 'remove `del` statements and modify alphashape __all__ (#89)',\n",
-       " 'including rtree in imports (#91)',\n",
-       " 'fix hardcoded swm test (#86)',\n",
-       " 'check for spatial index if nonplanar neighbors (#84)',\n",
-       " 'increment version number and add bugfixes, api changes (#79)',\n",
-       " 'Spherebug (#82)',\n",
-       " 'only warn once for islands/disconnected components (#83)',\n",
-       " 'deletion of extra spaces in warning message (#78)',\n",
-       " 'changed geometry column name from a str to an attribute (#76)',\n",
-       " 'add check for disconnected components (#65)',\n",
-       " 'clean up for release (#74)',\n",
-       " 'update for new examples (#72)']"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:17:07.731052Z",
+     "start_time": "2022-05-17T23:17:07.724113Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "pull_listing"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:17:10.222064Z",
+     "start_time": "2022-05-17T23:17:10.217762Z"
+    }
+   },
    "outputs": [],
    "source": [
     "message = \"We closed a total of {total} issues (enhancements and bug fixes) through {pr} pull requests\".format(total=n_total, pr=n_pulls)"
@@ -474,8 +507,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:17:10.807853Z",
+     "start_time": "2022-05-17T23:17:10.803257Z"
+    }
+   },
    "outputs": [],
    "source": [
     "message = \"{msg}, since our last release on {previous}.\".format(msg=message, previous=str(start_date))\n"
@@ -483,28 +521,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'We closed a total of 51 issues (enhancements and bug fixes) through 18 pull requests, since our last release on 2018-07-15.'"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:17:11.930347Z",
+     "start_time": "2022-05-17T23:17:11.923823Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "message"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:17:13.525550Z",
+     "start_time": "2022-05-17T23:17:13.522153Z"
+    }
+   },
    "outputs": [],
    "source": [
     "message += \"\\n\\n## Issues Closed\\n\""
@@ -512,28 +549,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "We closed a total of 51 issues (enhancements and bug fixes) through 18 pull requests, since our last release on 2018-07-15.\n",
-      "\n",
-      "## Issues Closed\n",
-      "\n"
-     ]
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:17:14.255527Z",
+     "start_time": "2022-05-17T23:17:14.250218Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "print(message)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:17:14.967383Z",
+     "start_time": "2022-05-17T23:17:14.963548Z"
+    }
+   },
    "outputs": [],
    "source": [
     "issues = \"\\n\".join([\"  - \"+issue for issue in issue_listing])\n",
@@ -545,80 +581,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "We closed a total of 51 issues (enhancements and bug fixes) through 18 pull requests, since our last release on 2018-07-15.\n",
-      "\n",
-      "## Issues Closed\n",
-      "  - error importing v3.0.7 (#100)\n",
-      "  - Lower case module names (#98)\n",
-      "  - remove function regime_weights (#96)\n",
-      "  - depreciating regime_weights in the new release? (#94)\n",
-      "  - inconsistency in api? (#93)\n",
-      "  - Ensure consistency in `from .module import *` in components of libpysal (#95)\n",
-      "  - [WIP] cleanup (#88)\n",
-      "  - docstrings for attributes are defined in properties (#87)\n",
-      "  - docstrings in W class need editing (#64)\n",
-      "  - version name as __version__ (#92)\n",
-      "  - remove `del` statements and modify alphashape __all__ (#89)\n",
-      "  - libpysal/libpysal/cg/__init__.py not importing `rtree` (#90)\n",
-      "  - including rtree in imports (#91)\n",
-      "  - fix hardcoded swm test (#86)\n",
-      "  - BUG:  test_weights_IO.py is using pysal and hard-coded paths (#85)\n",
-      "  - check for spatial index if nonplanar neighbors (#84)\n",
-      "  - nonplanar_neighbors fails when sindex is not constructed.  (#63)\n",
-      "  - increment version number and add bugfixes, api changes (#79)\n",
-      "  - Spherebug (#82)\n",
-      "  - only warn once for islands/disconnected components (#83)\n",
-      "  - only warn on disconnected components if there are no islands (#81)\n",
-      "  - LEP: Stuff/use pysal/network stuff to provide queen weights on linestring dataframes (#59)\n",
-      "  - swm fix not ported forward from pysal.  (#66)\n",
-      "  - import scipy syntax typo in the new issue template (#68)\n",
-      "  - deletion of extra spaces in warning message (#78)\n",
-      "  - Nightli.es build permissions (#77)\n",
-      "  - name of geometry column is hardcoded in nonplanar_neighbors (#75)\n",
-      "  - changed geometry column name from a str to an attribute (#76)\n",
-      "  - Missing example file  (#71)\n",
-      "  - if numba isn't present, libpysal warns every time imported (#73)\n",
-      "  - add check for disconnected components (#65)\n",
-      "  - clean up for release (#74)\n",
-      "  - update for new examples (#72)\n",
-      "\n",
-      "## Pull Requests\n",
-      "  - Lower case module names (#98)\n",
-      "  - remove function regime_weights (#96)\n",
-      "  - Ensure consistency in `from .module import *` in components of libpysal (#95)\n",
-      "  - [WIP] cleanup (#88)\n",
-      "  - docstrings for attributes are defined in properties (#87)\n",
-      "  - version name as __version__ (#92)\n",
-      "  - remove `del` statements and modify alphashape __all__ (#89)\n",
-      "  - including rtree in imports (#91)\n",
-      "  - fix hardcoded swm test (#86)\n",
-      "  - check for spatial index if nonplanar neighbors (#84)\n",
-      "  - increment version number and add bugfixes, api changes (#79)\n",
-      "  - Spherebug (#82)\n",
-      "  - only warn once for islands/disconnected components (#83)\n",
-      "  - deletion of extra spaces in warning message (#78)\n",
-      "  - changed geometry column name from a str to an attribute (#76)\n",
-      "  - add check for disconnected components (#65)\n",
-      "  - clean up for release (#74)\n",
-      "  - update for new examples (#72)\n"
-     ]
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:17:15.591401Z",
+     "start_time": "2022-05-17T23:17:15.587892Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "print(message)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:17:16.408755Z",
+     "start_time": "2022-05-17T23:17:16.403978Z"
+    }
+   },
    "outputs": [],
    "source": [
     "people = \"\\n\".join([\"  - \"+person for person in unique_authors])"
@@ -626,29 +609,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  - Serge Rey\n",
-      "  - Levi John Wolf\n",
-      "  - Wei Kang\n",
-      "  - James Gaboardi\n",
-      "  - Eli Knaap\n"
-     ]
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:17:17.109747Z",
+     "start_time": "2022-05-17T23:17:17.104026Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "print(people)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:17:18.339052Z",
+     "start_time": "2022-05-17T23:17:18.333927Z"
+    }
+   },
    "outputs": [],
    "source": [
     "message +=\"\\n\\nThe following individuals contributed to this release:\\n\\n{people}\".format(people=people)"
@@ -656,88 +637,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "We closed a total of 51 issues (enhancements and bug fixes) through 18 pull requests, since our last release on 2018-07-15.\n",
-      "\n",
-      "## Issues Closed\n",
-      "  - error importing v3.0.7 (#100)\n",
-      "  - Lower case module names (#98)\n",
-      "  - remove function regime_weights (#96)\n",
-      "  - depreciating regime_weights in the new release? (#94)\n",
-      "  - inconsistency in api? (#93)\n",
-      "  - Ensure consistency in `from .module import *` in components of libpysal (#95)\n",
-      "  - [WIP] cleanup (#88)\n",
-      "  - docstrings for attributes are defined in properties (#87)\n",
-      "  - docstrings in W class need editing (#64)\n",
-      "  - version name as __version__ (#92)\n",
-      "  - remove `del` statements and modify alphashape __all__ (#89)\n",
-      "  - libpysal/libpysal/cg/__init__.py not importing `rtree` (#90)\n",
-      "  - including rtree in imports (#91)\n",
-      "  - fix hardcoded swm test (#86)\n",
-      "  - BUG:  test_weights_IO.py is using pysal and hard-coded paths (#85)\n",
-      "  - check for spatial index if nonplanar neighbors (#84)\n",
-      "  - nonplanar_neighbors fails when sindex is not constructed.  (#63)\n",
-      "  - increment version number and add bugfixes, api changes (#79)\n",
-      "  - Spherebug (#82)\n",
-      "  - only warn once for islands/disconnected components (#83)\n",
-      "  - only warn on disconnected components if there are no islands (#81)\n",
-      "  - LEP: Stuff/use pysal/network stuff to provide queen weights on linestring dataframes (#59)\n",
-      "  - swm fix not ported forward from pysal.  (#66)\n",
-      "  - import scipy syntax typo in the new issue template (#68)\n",
-      "  - deletion of extra spaces in warning message (#78)\n",
-      "  - Nightli.es build permissions (#77)\n",
-      "  - name of geometry column is hardcoded in nonplanar_neighbors (#75)\n",
-      "  - changed geometry column name from a str to an attribute (#76)\n",
-      "  - Missing example file  (#71)\n",
-      "  - if numba isn't present, libpysal warns every time imported (#73)\n",
-      "  - add check for disconnected components (#65)\n",
-      "  - clean up for release (#74)\n",
-      "  - update for new examples (#72)\n",
-      "\n",
-      "## Pull Requests\n",
-      "  - Lower case module names (#98)\n",
-      "  - remove function regime_weights (#96)\n",
-      "  - Ensure consistency in `from .module import *` in components of libpysal (#95)\n",
-      "  - [WIP] cleanup (#88)\n",
-      "  - docstrings for attributes are defined in properties (#87)\n",
-      "  - version name as __version__ (#92)\n",
-      "  - remove `del` statements and modify alphashape __all__ (#89)\n",
-      "  - including rtree in imports (#91)\n",
-      "  - fix hardcoded swm test (#86)\n",
-      "  - check for spatial index if nonplanar neighbors (#84)\n",
-      "  - increment version number and add bugfixes, api changes (#79)\n",
-      "  - Spherebug (#82)\n",
-      "  - only warn once for islands/disconnected components (#83)\n",
-      "  - deletion of extra spaces in warning message (#78)\n",
-      "  - changed geometry column name from a str to an attribute (#76)\n",
-      "  - add check for disconnected components (#65)\n",
-      "  - clean up for release (#74)\n",
-      "  - update for new examples (#72)\n",
-      "\n",
-      "The following individuals contributed to this release:\n",
-      "\n",
-      "  - Serge Rey\n",
-      "  - Levi John Wolf\n",
-      "  - Wei Kang\n",
-      "  - James Gaboardi\n",
-      "  - Eli Knaap\n"
-     ]
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:17:18.955964Z",
+     "start_time": "2022-05-17T23:17:18.951062Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "print(message)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:17:19.780714Z",
+     "start_time": "2022-05-17T23:17:19.776314Z"
+    }
+   },
    "outputs": [],
    "source": [
     "head = \"# Changes\\n\\nVersion {version} ({release_date})\\n\\n\".format(version=__version__, release_date=release_date)"
@@ -745,126 +665,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "# Changes\n",
-      "\n",
-      "Version 3.0.8 (2018-08-22)\n",
-      "\n",
-      "We closed a total of 51 issues (enhancements and bug fixes) through 18 pull requests, since our last release on 2018-07-15.\n",
-      "\n",
-      "## Issues Closed\n",
-      "  - error importing v3.0.7 (#100)\n",
-      "  - Lower case module names (#98)\n",
-      "  - remove function regime_weights (#96)\n",
-      "  - depreciating regime_weights in the new release? (#94)\n",
-      "  - inconsistency in api? (#93)\n",
-      "  - Ensure consistency in `from .module import *` in components of libpysal (#95)\n",
-      "  - [WIP] cleanup (#88)\n",
-      "  - docstrings for attributes are defined in properties (#87)\n",
-      "  - docstrings in W class need editing (#64)\n",
-      "  - version name as __version__ (#92)\n",
-      "  - remove `del` statements and modify alphashape __all__ (#89)\n",
-      "  - libpysal/libpysal/cg/__init__.py not importing `rtree` (#90)\n",
-      "  - including rtree in imports (#91)\n",
-      "  - fix hardcoded swm test (#86)\n",
-      "  - BUG:  test_weights_IO.py is using pysal and hard-coded paths (#85)\n",
-      "  - check for spatial index if nonplanar neighbors (#84)\n",
-      "  - nonplanar_neighbors fails when sindex is not constructed.  (#63)\n",
-      "  - increment version number and add bugfixes, api changes (#79)\n",
-      "  - Spherebug (#82)\n",
-      "  - only warn once for islands/disconnected components (#83)\n",
-      "  - only warn on disconnected components if there are no islands (#81)\n",
-      "  - LEP: Stuff/use pysal/network stuff to provide queen weights on linestring dataframes (#59)\n",
-      "  - swm fix not ported forward from pysal.  (#66)\n",
-      "  - import scipy syntax typo in the new issue template (#68)\n",
-      "  - deletion of extra spaces in warning message (#78)\n",
-      "  - Nightli.es build permissions (#77)\n",
-      "  - name of geometry column is hardcoded in nonplanar_neighbors (#75)\n",
-      "  - changed geometry column name from a str to an attribute (#76)\n",
-      "  - Missing example file  (#71)\n",
-      "  - if numba isn't present, libpysal warns every time imported (#73)\n",
-      "  - add check for disconnected components (#65)\n",
-      "  - clean up for release (#74)\n",
-      "  - update for new examples (#72)\n",
-      "\n",
-      "## Pull Requests\n",
-      "  - Lower case module names (#98)\n",
-      "  - remove function regime_weights (#96)\n",
-      "  - Ensure consistency in `from .module import *` in components of libpysal (#95)\n",
-      "  - [WIP] cleanup (#88)\n",
-      "  - docstrings for attributes are defined in properties (#87)\n",
-      "  - version name as __version__ (#92)\n",
-      "  - remove `del` statements and modify alphashape __all__ (#89)\n",
-      "  - including rtree in imports (#91)\n",
-      "  - fix hardcoded swm test (#86)\n",
-      "  - check for spatial index if nonplanar neighbors (#84)\n",
-      "  - increment version number and add bugfixes, api changes (#79)\n",
-      "  - Spherebug (#82)\n",
-      "  - only warn once for islands/disconnected components (#83)\n",
-      "  - deletion of extra spaces in warning message (#78)\n",
-      "  - changed geometry column name from a str to an attribute (#76)\n",
-      "  - add check for disconnected components (#65)\n",
-      "  - clean up for release (#74)\n",
-      "  - update for new examples (#72)\n",
-      "\n",
-      "The following individuals contributed to this release:\n",
-      "\n",
-      "  - Serge Rey\n",
-      "  - Levi John Wolf\n",
-      "  - Wei Kang\n",
-      "  - James Gaboardi\n",
-      "  - Eli Knaap\n"
-     ]
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:17:20.392969Z",
+     "start_time": "2022-05-17T23:17:20.387513Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "print(head+message)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-05-17T23:17:21.419457Z",
+     "start_time": "2022-05-17T23:17:21.414924Z"
+    }
+   },
    "outputs": [],
    "source": [
     "outfile = 'changelog_{version}.md'.format(version=__version__)\n",
     "with open(outfile, 'w') as of:\n",
     "    of.write(head+message)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:py39_libpysal]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-py39_libpysal-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -876,7 +710,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.9.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR swaps out `libpysal` for `access` in the `gitcount` notebook for changelog generation. 

xref [#31](https://github.com/pysal/access/issues/31#issuecomment-1127882074)