### PR TITLE
fix url location for example datasets

### DIFF
--- a/access/datasets.py
+++ b/access/datasets.py
@@ -24,7 +24,7 @@ class Datasets(object):
             "cook_county_tracts": "cook_county_tracts.geojson",
         }
 
-        url = f"https://uchicago-csds-access.s3.amazonaws.com/ex_datasets/{_datasets[key]}"
+        url = f"https://d2r7gabxtstf5s.cloudfront.net/ex_datasets/{_datasets[key]}"
 
         if ".geojson" in url:
             import geopandas as gpd

--- a/access/tests/test_floating_catchment_area.py
+++ b/access/tests/test_floating_catchment_area.py
@@ -67,7 +67,7 @@ class TestFloatingCatchmentArea(unittest.TestCase):
             columns=["x", "y", "value", "geometry"],
             index=[28, 29],
         )
-        self.model.demand_df = self.model.demand_df.append(new_dem_row)
+        self.model.demand_df = pd.concat([self.model.demand_df, new_dem_row])
         self.model.demand_df.index.name = "id"
         result = self.model.fca_ratio(noise=True)
 


### PR DESCRIPTION
Example datasets were moved to sit behind CDN.