### PR TITLE
`ruff` access - part 1 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-access/_version.py export-subst

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,12 @@
-repos: 
--   repo: https://github.com/psf/black
-    rev: 22.3.0
-    hooks: 
-    - id: black
-      language_version: python3
+#---
+#files: "access\/"
+#repos:
+#  - repo: https://github.com/astral-sh/ruff-pre-commit
+#    rev: "v0.12.0"
+#    hooks:
+#      - id: ruff-check
+#      - id: ruff-format
+#
+#ci:
+#  autofix_prs: false
+#  autoupdate_schedule: quarterly

--- a/access/helpers.py
+++ b/access/helpers.py
@@ -1,35 +1,28 @@
 def sanitize_supply_cost(a, cost, name):
-
     if cost is None:
-
         cost = a.default_cost
         if len(a.cost_names) > 1:
-            a.log.info("Using default cost, {}, for {}.".format(cost, name))
+            a.log.info(f"Using default cost, {cost}, for {name}.")
 
     if cost not in a.cost_names:
-
-        raise ValueError("{} not an available cost.".format(cost))
+        raise ValueError(f"{cost} not an available cost.")
 
     return cost
 
 
 def sanitize_demand_cost(a, cost, name):
-
     if cost is None:
-
         cost = a.neighbor_default_cost
         if len(a.cost_names) > 1:
-            a.log.info("Using default neighbor cost, {}, for {}.".format(cost, name))
+            a.log.info(f"Using default neighbor cost, {cost}, for {name}.")
 
     if cost not in a.neighbor_cost_names:
-
-        raise ValueError("{} not an available neighbor cost.".format(cost))
+        raise ValueError(f"{cost} not an available neighbor cost.")
 
     return cost
 
 
 def sanitize_supplies(a, supply_values):
-
     if type(supply_values) is str:
         supply_values = [supply_values]
     elif supply_values is None:
@@ -43,7 +36,6 @@ def sanitize_supplies(a, supply_values):
 
 
 def normalized_access(a, columns):
-
     mean_access_values = (
         a.access_df[columns].multiply(a.access_df[a.demand_value], axis=0).sum()
         / a.access_df[a.demand_value].sum()

--- a/access/raam.py
+++ b/access/raam.py
@@ -13,13 +13,11 @@ def iterate_raam(
     limit_initial=20,
     verbose=False,
 ):
-
     norig, ndest = travel.shape
     assignment = np.zeros((norig, ndest))
     assignment[range(norig), travel.argmin(axis=1)] = demand
 
     for i in range(max_cycles):
-
         demand_at_supply = assignment.sum(axis=0)
         congestion_cost = demand_at_supply / supply
         total_cost = congestion_cost + travel
@@ -58,7 +56,6 @@ def iterate_raam(
             delta = np.minimum(delta, step_size * demand).astype(int)
 
         else:
-
             step_size = int(np.round(initial_step * 0.5 ** (i / half_life)))
             if step_size < min_step:
                 step_size = min_step
@@ -69,7 +66,6 @@ def iterate_raam(
         ## This will only happen in the first 10-20 cycles.
         ## So only do these (somewhat costly checks) then.
         if i < limit_initial:
-
             delta_mat = np.zeros(travel.shape)
             delta_mat[range(norig), min_locations] += delta
 
@@ -90,9 +86,7 @@ def iterate_raam(
 
             if verbose:
                 print(
-                    "{:d} {:.2f} {:d} {:.3f}".format(
-                        i, raam_cost.mean(), delta.sum(), step_size
-                    ),
+                    f"{i:d} {raam_cost.mean():.2f} {delta.sum():d} {step_size:.3f}",
                     end=" || ",
                 )
 
@@ -164,7 +158,7 @@ def raam(
     access     : pandas.Series
 
                   A -- potentially-weighted -- Rational Agent Access Model cost.
-    """
+    """  # noqa: E501
 
     if demand_index is not True:
         demand_df = demand_df.set_index(demand_index)
@@ -180,7 +174,7 @@ def raam(
     cost_pivot = cost_df.pivot(index=cost_origin, columns=cost_dest, values=cost_name)
     try:
         travel_np = cost_pivot.loc[demand_locations, supply_locations].to_numpy().copy()
-    except:
+    except:  # noqa: E722 –– Do not use bare `except`
         travel_np = cost_pivot.loc[demand_locations, supply_locations].values.copy()
 
     travel_np = travel_np / tau
@@ -192,7 +186,7 @@ def raam(
 
     try:
         supply_np = supply_df.loc[supply_locations, supply_name].to_numpy().copy()
-    except:
+    except:  # noqa: E722 –– Do not use bare `except`
         supply_np = supply_df.loc[supply_locations, supply_name].values.copy()
 
     supply_np = supply_np * rho
@@ -200,7 +194,7 @@ def raam(
     # Change this -- should be
     try:
         demand_np = demand_df.loc[demand_locations, demand_name].to_numpy().copy()
-    except:
+    except:  # noqa: E722 –– Do not use bare `except`
         demand_np = demand_df.loc[demand_locations, demand_name].values.copy()
 
     raam_cost = iterate_raam(

--- a/access/weights.py
+++ b/access/weights.py
@@ -33,7 +33,7 @@ def step_fn(step_dict):
     {0: 1, 10: 1, 20: 1, 30: 0.68, 40: 0.68, 50: 0.22, 60: 0.22, 70: 0}
     """
 
-    if type(step_dict) != dict:
+    if not isinstance(step_dict, dict):
         raise TypeError("step_dict must be of type dict.")
 
     for v in step_dict.values():
@@ -41,7 +41,6 @@ def step_fn(step_dict):
             raise ValueError("All weights must be positive.")
 
     def helper(key_to_test):
-
         for k, v in sorted(step_dict.items()):
             if key_to_test <= k:
                 return v
@@ -53,10 +52,10 @@ def step_fn(step_dict):
 
 def gaussian(sigma):
     """
-    Create a gaussian weight function, for a specified width, :math:`\sigma`.
+    Create a gaussian weight function, for a specified width, :math:`\\sigma`.
     The mean / location parameter is assumed to be 0.
-    Note that the standard normalization of the Gaussian, :math:`1 / \sqrt{2\pi\sigma^2}`,
-    is *not* applied, so :math:`f(0) = 1` regardless of the value of :math:`\sigma`.
+    Note that the standard normalization of the Gaussian, :math:`1 / \\sqrt{2\\pi\\sigma^2}`,
+    is *not* applied, so :math:`f(0) = 1` regardless of the value of :math:`\\sigma`.
     Of course, this is irrelevant if the ultimate access values are ultimately normalized.
 
     Parameters
@@ -90,7 +89,7 @@ def gaussian(sigma):
     >>> import numpy as np
     >>> {x : np.exp(-x**2/2) for x in range(4)}
     {0: 1.0, 1: 0.6065306597126334, 2: 0.1353352832366127, 3: 0.011108996538242306}
-    """
+    """  # noqa: E501
 
     if sigma == 0:
         raise ValueError("Sigma must be non-zero.")
@@ -138,6 +137,6 @@ def gravity(scale, alpha, min_dist=0):
 
     >>> {t : round(fn(t), 2) for t in [0, 1, 2, 20, 40, 60]}
     {0: 400.0, 1: 400.0, 2: 100.0, 20: 1.0, 40: 0.25, 60: 0.11}
-    """
+    """  # noqa: E501
 
     return lambda x: np.power(max(x, min_dist) / scale, alpha)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ tests = [
     "pytest",
     "pytest-cov",
     "pytest-xdist",
+    "ruff",
 ]
 docs = [
     "nbsphinx",
@@ -74,6 +75,20 @@ all = ["access[tests,docs,notebooks]"]
 
 [tool.setuptools.packages.find]
 include = ["access", "access.*"]
+
+
+[tool.ruff]
+line-length = 88
+extend-include = ["*.ipynb"]
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP", "N", "B", "A", "C4", "SIM", "ARG"]
+
+[tool.ruff.lint.per-file-ignores]
+ "*__init__.py" = [
+     "F401",  # imported but unused
+     "F403",  # star import; unable to detect undefined names
+ ]
 
 
 [tool.coverage.run]


### PR DESCRIPTION
#### `ruff` access - part 1 

* kick off #65 
  * format and lint `helpers.py`, `raam.py`, `weights.py`  
  * `__init__.py` already in good shape
* xref #67 
  * update `pre-commit`, but leave commented until ruffening is complete
  * once complete, uncomment and close out that ticket
* remove `.gitattributes` – no longer using versioneer 