### PR TITLE
ruff access - part 4 + convert to `pytest`

### DIFF
--- a/access/tests/test_access.py
+++ b/access/tests/test_access.py
@@ -1,14 +1,8 @@
-from access import Access
-from access.access import weights
-
-import math
 import unittest
 
-import numpy as np
-import pandas as pd
-import geopandas as gpd
-
 import util as tu
+
+from access import Access
 
 
 class TestAccess(unittest.TestCase):
@@ -276,7 +270,7 @@ class TestAccess(unittest.TestCase):
                 neighbor_cost_name=bad_cost_name,
             )
 
-    def test_access_initialize_without_valid_neighbor_cost_name_in_list_raises_value_error(
+    def test_access_initialize_without_valid_neighbor_cost_name_in_list_raises_value_error(  # noqa: E501
         self,
     ):
         with self.assertRaises(ValueError):

--- a/access/tests/test_access.py
+++ b/access/tests/test_access.py
@@ -1,19 +1,18 @@
-import unittest
-
+import pytest
 import util as tu
 
 from access import Access
 
 
-class TestAccess(unittest.TestCase):
-    def setUp(self):
+class TestAccess:
+    def setup_method(self):
         n = 5
         self.supply_grid = tu.create_nxn_grid(n)
         self.demand_grid = self.supply_grid.sample(1)
         self.cost_matrix = tu.create_cost_matrix(self.supply_grid, "euclidean")
 
     def test_access_initialize_without_demand_index_col_raises_value_error(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             bad_index_name = "Not a col in demand df"
 
             Access(
@@ -26,7 +25,7 @@ class TestAccess(unittest.TestCase):
             )
 
     def test_access_initialize_without_supply_index_col_raises_value_error(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             bad_index_name = "Not a col in supply df"
 
             Access(
@@ -39,7 +38,7 @@ class TestAccess(unittest.TestCase):
             )
 
     def test_access_initialize_without_demand_value_col_raises_value_error(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             bad_value_name = "Not a col in demand df"
 
             Access(
@@ -52,7 +51,7 @@ class TestAccess(unittest.TestCase):
             )
 
     def test_access_initialize_without_supply_value_col_raises_value_error(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             bad_value_name = "Not a col in supply df"
 
             Access(
@@ -67,7 +66,7 @@ class TestAccess(unittest.TestCase):
     def test_access_initialize_without_supply_value_col_in_list_raises_value_error(
         self,
     ):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             bad_value_name = ["Not a col in supply df"]
 
             Access(
@@ -93,10 +92,10 @@ class TestAccess(unittest.TestCase):
 
         actual = self.model.supply_types
 
-        self.assertEqual(actual, ["value"])
+        assert actual == ["value"]
 
     def test_access_initialize_with_supply_value_col_in_dict_raises_value_error(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             value_in_dict = {"value": ""}
 
             self.model = Access(
@@ -109,7 +108,7 @@ class TestAccess(unittest.TestCase):
             )
 
     def test_access_initialize_without_valid_cost_origin_raises_value_error(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             bad_cost_origin = "Not a valid cost origin column"
 
             Access(
@@ -126,7 +125,7 @@ class TestAccess(unittest.TestCase):
             )
 
     def test_access_initialize_without_valid_cost_dest_raises_value_error(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             bad_cost_dest = "Not a valid cost dest column"
 
             Access(
@@ -143,7 +142,7 @@ class TestAccess(unittest.TestCase):
             )
 
     def test_access_initialize_without_valid_cost_name_raises_value_error(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             bad_cost_name = "Not a valid cost name column"
 
             Access(
@@ -160,7 +159,7 @@ class TestAccess(unittest.TestCase):
             )
 
     def test_access_initialize_without_valid_cost_name_in_list_raises_value_error(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             bad_cost_name = ["Not a valid cost name column"]
 
             Access(
@@ -194,10 +193,10 @@ class TestAccess(unittest.TestCase):
 
         actual = self.model.cost_names
 
-        self.assertEqual(actual, ["cost"])
+        assert actual == ["cost"]
 
     def test_access_initialize_with_valid_cost_name_in_dict_raises_value_error(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             cost_name_dict = {"cost": ""}
 
             self.model = Access(
@@ -216,7 +215,7 @@ class TestAccess(unittest.TestCase):
     def test_access_initialize_without_valid_neighbor_cost_origin_raises_value_error(
         self,
     ):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             bad_cost_origin = "Not a valid cost origin column"
 
             Access(
@@ -235,7 +234,7 @@ class TestAccess(unittest.TestCase):
     def test_access_initialize_without_valid_neighbor_cost_dest_raises_value_error(
         self,
     ):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             bad_cost_dest = "Not a valid cost dest column"
 
             Access(
@@ -254,7 +253,7 @@ class TestAccess(unittest.TestCase):
     def test_access_initialize_without_valid_neighbor_cost_name_raises_value_error(
         self,
     ):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             bad_cost_name = "Not a valid cost name column"
 
             Access(
@@ -273,7 +272,7 @@ class TestAccess(unittest.TestCase):
     def test_access_initialize_without_valid_neighbor_cost_name_in_list_raises_value_error(  # noqa: E501
         self,
     ):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             bad_cost_name = ["Not a valid cost name column"]
 
             Access(
@@ -307,12 +306,12 @@ class TestAccess(unittest.TestCase):
 
         actual = self.model.neighbor_cost_names
 
-        self.assertEqual(actual, ["cost"])
+        assert actual == ["cost"]
 
     def test_access_initialize_with_valid_neighbor_cost_name_in_dict_raises_value_error(
         self,
     ):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             cost_name_dict = {"cost": ""}
 
             self.model = Access(

--- a/access/tests/test_datasets.py
+++ b/access/tests/test_datasets.py
@@ -1,7 +1,8 @@
 import unittest
 
-import pandas as pd
 import geopandas as gpd
+import pandas as pd
+
 from access import Datasets
 
 

--- a/access/tests/test_datasets.py
+++ b/access/tests/test_datasets.py
@@ -1,12 +1,10 @@
-import unittest
-
 import geopandas as gpd
 import pandas as pd
 
 from access import Datasets
 
 
-class TestDatasets(unittest.TestCase):
+class TestDatasets:
     def test_load_geopandas_dataset(self):
         result = Datasets.load_data("chi_doc_geom")
         assert isinstance(result, gpd.GeoDataFrame)

--- a/access/tests/test_euclidean.py
+++ b/access/tests/test_euclidean.py
@@ -1,13 +1,9 @@
-from access import Access
-from access.access import weights
-
-import math
 import unittest
 
-import numpy as np
-import pandas as pd
 import geopandas as gpd
-import util as tu
+import pandas as pd
+
+from access import Access
 
 
 class TestEuclidean(unittest.TestCase):
@@ -67,12 +63,12 @@ class TestEuclidean(unittest.TestCase):
 
         self.assertAlmostEqual(actual, 0)
 
-    def test_euclidean_without_geopandas_demand_dataframe_raises_TypeError(self):
+    def test_euclidean_without_geopandas_demand_dataframe_raises_type_error(self):
         with self.assertRaises(TypeError):
             self.model.demand_df = self.model.demand_df[["x", "y", "value"]]
             self.model.create_euclidean_distance()
 
-    def test_euclidean_without_geopandas_supply_dataframe_raises_TypeError(self):
+    def test_euclidean_without_geopandas_supply_dataframe_raises_type_error(self):
         with self.assertRaises(TypeError):
             self.model.supply_df = self.model.supply_df[["x", "y", "value"]]
             self.model.create_euclidean_distance()
@@ -169,7 +165,7 @@ class TestEuclideanNeighbors(unittest.TestCase):
             0,
         )
 
-    def test_euclidean_neighbors_without_geopandas_demand_dataframe_raises_TypeError(
+    def test_euclidean_neighbors_without_geopandas_demand_dataframe_raises_type_error(
         self,
     ):
         with self.assertRaises(TypeError):

--- a/access/tests/test_euclidean.py
+++ b/access/tests/test_euclidean.py
@@ -1,13 +1,12 @@
-import unittest
-
 import geopandas as gpd
 import pandas as pd
+import pytest
 
 from access import Access
 
 
-class TestEuclidean(unittest.TestCase):
-    def setUp(self):
+class TestEuclidean:
+    def setup_method(self):
         demand_data = pd.DataFrame({"id": [0], "x": [0], "y": [0], "value": [1]})
         demand_grid = gpd.GeoDataFrame(
             demand_data, geometry=gpd.points_from_xy(demand_data.x, demand_data.y)
@@ -45,7 +44,7 @@ class TestEuclidean(unittest.TestCase):
         )
         actual = self.model.cost_df["euclidian"][0]
 
-        self.assertAlmostEqual(actual, 1)
+        assert pytest.approx(actual) == 1
 
     def test_euclidean_point_to_poly(self):
         self.model.create_euclidean_distance(
@@ -53,7 +52,7 @@ class TestEuclidean(unittest.TestCase):
         )
         actual = self.model.cost_df["euclidian"][0]
 
-        self.assertAlmostEqual(actual, 0.5)
+        assert pytest.approx(actual) == 0.5
 
     def test_euclidean_poly_to_poly(self):
         self.model.create_euclidean_distance(
@@ -61,15 +60,15 @@ class TestEuclidean(unittest.TestCase):
         )
         actual = self.model.cost_df["euclidian"][0]
 
-        self.assertAlmostEqual(actual, 0)
+        assert pytest.approx(actual) == 0
 
     def test_euclidean_without_geopandas_demand_dataframe_raises_type_error(self):
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             self.model.demand_df = self.model.demand_df[["x", "y", "value"]]
             self.model.create_euclidean_distance()
 
     def test_euclidean_without_geopandas_supply_dataframe_raises_type_error(self):
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             self.model.supply_df = self.model.supply_df[["x", "y", "value"]]
             self.model.create_euclidean_distance()
 
@@ -79,11 +78,11 @@ class TestEuclidean(unittest.TestCase):
 
         actual = hasattr(self.model, "_default_cost")
 
-        self.assertEqual(actual, True)
+        assert actual
 
 
-class TestEuclideanNeighbors(unittest.TestCase):
-    def setUp(self):
+class TestEuclideanNeighbors:
+    def setup_method(self):
         demand_data = pd.DataFrame(
             {"id": [0, 1], "x": [0, 0], "y": [0, 1], "value": [1, 1]}
         )
@@ -140,14 +139,16 @@ class TestEuclideanNeighbors(unittest.TestCase):
         self.model.create_euclidean_distance_neighbors(
             name="euclidean", threshold=2, centroid=True
         )
-        self.assertAlmostEqual(
-            (
-                self.model.neighbor_cost_df.euclidean
-                - self.model.neighbor_cost_df.ctr_expectation
+        assert (
+            pytest.approx(
+                (
+                    self.model.neighbor_cost_df.euclidean
+                    - self.model.neighbor_cost_df.ctr_expectation
+                )
+                .abs()
+                .max(),
             )
-            .abs()
-            .max(),
-            0,
+            == 0
         )
 
     def test_euclidean_neighbors_poly(self):
@@ -155,20 +156,22 @@ class TestEuclideanNeighbors(unittest.TestCase):
             name="euclidean", threshold=2, centroid=False
         )
 
-        self.assertAlmostEqual(
-            (
-                self.model.neighbor_cost_df.euclidean
-                - self.model.neighbor_cost_df.buf_expectation
+        assert (
+            pytest.approx(
+                (
+                    self.model.neighbor_cost_df.euclidean
+                    - self.model.neighbor_cost_df.buf_expectation
+                )
+                .abs()
+                .max()
             )
-            .abs()
-            .max(),
-            0,
+            == 0
         )
 
     def test_euclidean_neighbors_without_geopandas_demand_dataframe_raises_type_error(
         self,
     ):
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             self.model.demand_df = self.model.demand_df[["x", "y", "value"]]
             self.model.create_euclidean_distance_neighbors()
 
@@ -178,4 +181,4 @@ class TestEuclideanNeighbors(unittest.TestCase):
 
         actual = hasattr(self.model, "_neighbor_default_cost")
 
-        self.assertEqual(actual, True)
+        assert actual


### PR DESCRIPTION
* format and lint + convert to `pytest`
  * `tests/test_access.py`
  * `tests/test_datasets.py`
  * `tests/test_euclidean.py`
* xrefs
  * #65   