### PR TITLE
`ruff` access - part 6 + convert to `pytest`

### DIFF
--- a/access/tests/test_misc.py
+++ b/access/tests/test_misc.py
@@ -1,13 +1,8 @@
-from access import Access
-from access.access import weights
-
-import math
 import unittest
 
-import numpy as np
-import pandas as pd
-import geopandas as gpd
 import util as tu
+
+from access import Access
 
 
 class TestMisc(unittest.TestCase):
@@ -116,18 +111,6 @@ class TestMisc(unittest.TestCase):
         )
 
         actual = "new_cost" in self.model.neighbor_cost_df.columns
-
-        self.assertEqual(actual, True)
-
-    def test_user_cost_adds_new_column_to_cost_names(self):
-        new_cost = self.model.neighbor_cost_df.copy()
-        new_cost["new_cost"] = 0
-
-        self.model.append_user_cost_neighbors(
-            new_cost_df=new_cost, name="new_cost", origin="origin", destination="dest"
-        )
-
-        actual = "new_cost" in self.model.neighbor_cost_names
 
         self.assertEqual(actual, True)
 

--- a/access/tests/test_misc.py
+++ b/access/tests/test_misc.py
@@ -1,12 +1,11 @@
-import unittest
-
+import pytest
 import util as tu
 
 from access import Access
 
 
-class TestMisc(unittest.TestCase):
-    def setUp(self):
+class TestMisc:
+    def setup_method(self):
         n = 5
         supply_grid = tu.create_nxn_grid(n)
         demand_grid = supply_grid.sample(1)
@@ -35,7 +34,7 @@ class TestMisc(unittest.TestCase):
         expected = self.model.access_df["raam_value"].iloc[0] / 2
         actual = self.model.access_df["score"].iloc[0]
 
-        self.assertEqual(actual, expected)
+        assert actual == expected
 
     def test_score_run_again_and_test_overwrite(self):
         self.model.raam()
@@ -45,10 +44,10 @@ class TestMisc(unittest.TestCase):
         expected = self.model.access_df["raam_value"].iloc[0] / 4
         actual = self.model.access_df["score"].iloc[0]
 
-        self.assertEqual(actual, expected)
+        assert actual == expected
 
     def test_score_invalid_access_value_raises_value_error(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             bad_access_value = "Not in access df"
             self.model.score(col_dict={bad_access_value: 0.5})
 
@@ -58,10 +57,10 @@ class TestMisc(unittest.TestCase):
         self.model.default_cost = "new_cost"
         actual = self.model.default_cost
 
-        self.assertEqual(actual, "new_cost")
+        assert actual == "new_cost"
 
     def test_set_cost_unavailable_cost_measure_raises_value_error(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             bad_cost_name = "Not an available cost name"
             self.model.default_cost = bad_cost_name
 
@@ -71,10 +70,10 @@ class TestMisc(unittest.TestCase):
         self.model.neighbor_default_cost = "new_cost"
         actual = self.model.neighbor_default_cost
 
-        self.assertEqual(actual, "new_cost")
+        assert actual == "new_cost"
 
     def test_set_cost_neighbors_unavailable_cost_measure_raises_value_error(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             bad_cost_name = "Not an available cost name"
             self.model.neighbor_default_cost = bad_cost_name
 
@@ -88,7 +87,7 @@ class TestMisc(unittest.TestCase):
 
         actual = "new_cost" in self.model.cost_df.columns
 
-        self.assertEqual(actual, True)
+        assert actual
 
     def test_user_cost_adds_new_column_to_cost_names(self):
         new_cost = self.model.cost_df.copy()
@@ -100,7 +99,7 @@ class TestMisc(unittest.TestCase):
 
         actual = "new_cost" in self.model.cost_names
 
-        self.assertEqual(actual, True)
+        assert actual
 
     def test_user_cost_neighbors_adds_new_column_to_neighbor_cost_df(self):
         new_cost = self.model.neighbor_cost_df.copy()
@@ -112,7 +111,7 @@ class TestMisc(unittest.TestCase):
 
         actual = "new_cost" in self.model.neighbor_cost_df.columns
 
-        self.assertEqual(actual, True)
+        assert actual
 
     def test_norm_access_df(self):
         self.model.raam()
@@ -122,8 +121,8 @@ class TestMisc(unittest.TestCase):
 
         actual1 = normalized_df["fca_value"].iloc[0]
 
-        self.assertEqual(actual1, 1)
+        assert actual1 == 1
 
         actual2 = normalized_df["raam_value"].iloc[0]
 
-        self.assertEqual(actual2, 1)
+        assert actual2 == 1

--- a/access/tests/test_raam.py
+++ b/access/tests/test_raam.py
@@ -1,12 +1,10 @@
-import unittest
-
 import util as tu
 
 from access import Access
 
 
-class TestRAAM(unittest.TestCase):
-    def setUp(self):
+class TestRAAM:
+    def setup_method(self):
         n = 5
         supply_grid = tu.create_nxn_grid(n)
         demand_grid = supply_grid.sample(1)
@@ -35,7 +33,7 @@ class TestRAAM(unittest.TestCase):
         expected = self.model.supply_df.value.sum()
         actual = self.model.access_df["raam_value"].iloc[0]
 
-        self.assertEqual(expected, actual)
+        assert expected == actual
 
     def test_raam_single_demand_location_equals_sum_of_supply_initial_step_int(self):
         self.model.raam(initial_step=1)
@@ -43,7 +41,7 @@ class TestRAAM(unittest.TestCase):
         expected = self.model.supply_df.value.sum()
         actual = self.model.access_df["raam_value"].iloc[0]
 
-        self.assertEqual(expected, actual)
+        assert expected == actual
 
     def test_raam_single_demand_location_equals_sum_of_supply_min_step(self):
         self.model.raam(min_step=1, verbose=True)
@@ -51,7 +49,7 @@ class TestRAAM(unittest.TestCase):
         expected = self.model.supply_df.value.sum()
         actual = self.model.access_df["raam_value"].iloc[0]
 
-        self.assertEqual(expected, actual)
+        assert expected == actual
 
     def test_raam_run_again_and_test_overwrite(self):
         self.model.raam()
@@ -60,11 +58,11 @@ class TestRAAM(unittest.TestCase):
         expected = self.model.supply_df.value.sum()
         actual = self.model.access_df["raam_value"].iloc[0]
 
-        self.assertEqual(expected, actual)
+        assert expected == actual
 
     def test_raam_single_demand_location_equals_sum_of_supply_normalize(self):
         self.model.raam(normalize=True)
 
         actual = self.model.access_df["raam_value"].iloc[0]
 
-        self.assertEqual(actual, 25)
+        assert actual == 25

--- a/access/tests/test_raam.py
+++ b/access/tests/test_raam.py
@@ -1,13 +1,8 @@
-from access import Access
-from access.access import weights
-
-import math
 import unittest
 
-import numpy as np
-import pandas as pd
-import geopandas as gpd
 import util as tu
+
+from access import Access
 
 
 class TestRAAM(unittest.TestCase):

--- a/access/tests/test_weighted_catchment.py
+++ b/access/tests/test_weighted_catchment.py
@@ -1,13 +1,12 @@
-import unittest
-
+import pytest
 import util as tu
 
 from access import Access
 from access.access import weights
 
 
-class TestWeightedCatchment(unittest.TestCase):
-    def setUp(self):
+class TestWeightedCatchment:
+    def setup_method(self):
         n = 5
         supply_grid = tu.create_nxn_grid(n)
         demand_grid = supply_grid.sample(1)
@@ -33,7 +32,7 @@ class TestWeightedCatchment(unittest.TestCase):
             name="test", weight_fn=weights.step_fn({catchment: weight})
         )
         actual = result.iloc[0]["test_value"]
-        self.assertEqual(actual, 1)
+        assert actual == 1
 
     def test_weighted_catchment_small_catchment_weight_x(self):
         catchment = 0.5
@@ -42,7 +41,7 @@ class TestWeightedCatchment(unittest.TestCase):
             name="test", weight_fn=weights.step_fn({catchment: weight})
         )
         actual = result.iloc[0]["test_value"]
-        self.assertEqual(actual, 0.5)
+        assert actual == 0.5
 
     def test_weighted_catchment_large_catchment_weight_1(self):
         catchment = 10
@@ -51,7 +50,7 @@ class TestWeightedCatchment(unittest.TestCase):
             name="test", weight_fn=weights.step_fn({catchment: weight})
         )
         actual = result.iloc[0]["test_value"]
-        self.assertEqual(actual, 25)
+        assert actual == 25
 
     def test_weighted_catchment_run_again_and_test_overwrite(self):
         catchment = 0.5
@@ -63,7 +62,7 @@ class TestWeightedCatchment(unittest.TestCase):
             name="test", weight_fn=weights.step_fn({catchment: weight})
         )
         actual = result.iloc[0]["test_value"]
-        self.assertEqual(actual, 1)
+        assert actual == 1
 
     def test_weighted_catchment_large_catchment_weight_1_normalized(self):
         catchment = 10
@@ -72,7 +71,7 @@ class TestWeightedCatchment(unittest.TestCase):
             name="test", weight_fn=weights.step_fn({catchment: weight}), normalize=True
         )
         actual = result.iloc[0]["test_value"]
-        self.assertEqual(actual, 1)
+        assert actual == 1
 
     def test_weighted_catchment_with_gravity_weights(self):
         n = 5
@@ -108,8 +107,4 @@ class TestWeightedCatchment(unittest.TestCase):
         for _id, expected in zip(ids, expected_vals, strict=False):
             actual = self.model.access_df.gravity_value.loc[_id]
 
-            self.assertAlmostEqual(actual, expected)
-
-
-if __name__ == "__main__":
-    unittest.main()
+            assert pytest.approx(actual) == expected

--- a/access/tests/test_weighted_catchment.py
+++ b/access/tests/test_weighted_catchment.py
@@ -1,13 +1,9 @@
-from access import Access
-from access.access import weights
-
-import math
 import unittest
 
-import numpy as np
-import pandas as pd
-import geopandas as gpd
 import util as tu
+
+from access import Access
+from access.access import weights
 
 
 class TestWeightedCatchment(unittest.TestCase):
@@ -109,8 +105,8 @@ class TestWeightedCatchment(unittest.TestCase):
             1.133733026,
         ]
 
-        for id, expected in zip(ids, expected_vals):
-            actual = self.model.access_df.gravity_value.loc[id]
+        for _id, expected in zip(ids, expected_vals, strict=False):
+            actual = self.model.access_df.gravity_value.loc[_id]
 
             self.assertAlmostEqual(actual, expected)
 

--- a/access/tests/test_weights.py
+++ b/access/tests/test_weights.py
@@ -1,13 +1,13 @@
-import unittest
 from random import randint
 
 import pandas as pd
+import pytest
 
 from access.access import weights
 
 
-class TestWeights(unittest.TestCase):
-    def setUp(self):
+class TestWeights:
+    def setup_method(self):
         self.r_int = randint(2, 101)
         self.series = pd.Series(range(1, self.r_int))
 
@@ -22,7 +22,7 @@ class TestWeights(unittest.TestCase):
         w_applied = self.apply_weight_fn(weight_fn)
 
         expected = w_applied.sum()
-        self.assertEqual(expected, 0)
+        assert expected == 0
 
     def test_step_fn_all_weight_one_equals_self(self):
         weight_fn = weights.step_fn({self.r_int: 1})
@@ -31,7 +31,7 @@ class TestWeights(unittest.TestCase):
         expected = w_applied.sum()
         actual = self.series.sum()
 
-        self.assertEqual(expected, actual)
+        assert expected == actual
 
     def test_step_fn_all_weight_half_equals_half(self):
         weight_fn = weights.step_fn({self.r_int: 0.5})
@@ -40,7 +40,7 @@ class TestWeights(unittest.TestCase):
         expected = w_applied.sum()
         actual = self.series.sum() / 2
 
-        self.assertEqual(expected, actual)
+        assert expected == actual
 
     def test_step_fn_all_weight_two_equals_twice(self):
         weight_fn = weights.step_fn({self.r_int: 2})
@@ -49,27 +49,27 @@ class TestWeights(unittest.TestCase):
         expected = w_applied.sum()
         actual = self.series.sum() * 2
 
-        self.assertEqual(expected, actual)
+        assert expected == actual
 
     def test_step_fn_negative_weight_raises_error(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             weights.step_fn({self.r_int: -1})
 
     def test_step_fn_non_dict_input_raises_error(self):
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             weights.step_fn(1)
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             weights.step_fn("a")
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             weights.step_fn([])
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             weights.step_fn(1.0)
 
     def test_gaussian_width_zero_raises_error(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             weight_fn = weights.gaussian(0)
             self.apply_weight_fn(weight_fn)
 
@@ -79,7 +79,7 @@ class TestWeights(unittest.TestCase):
 
         actual = w_applied.loc[0]
 
-        self.assertAlmostEqual(actual, 0.6065306597)
+        assert pytest.approx(actual) == 0.6065306597
 
     def test_gaussian_weight_sigma_varied(self):
         sigma_vals = [-50, -2, 2, 50]
@@ -95,7 +95,7 @@ class TestWeights(unittest.TestCase):
             print(w_applied.loc[0])
             actual = w_applied.loc[0]
 
-            self.assertAlmostEqual(actual, expected)
+            assert pytest.approx(actual) == expected
 
     def test_gravity_with_zero_alpha(self):
         rand_int = randint(1, 100)
@@ -104,4 +104,4 @@ class TestWeights(unittest.TestCase):
 
         actual = w_applied.loc[0]
 
-        self.assertEqual(actual, 1)
+        assert actual == 1

--- a/access/tests/test_weights.py
+++ b/access/tests/test_weights.py
@@ -1,12 +1,9 @@
-from access.access import weights
-
-import math
 import unittest
 from random import randint
 
-import numpy as np
 import pandas as pd
-import util as tu
+
+from access.access import weights
 
 
 class TestWeights(unittest.TestCase):
@@ -56,7 +53,7 @@ class TestWeights(unittest.TestCase):
 
     def test_step_fn_negative_weight_raises_error(self):
         with self.assertRaises(ValueError):
-            weight_fn = weights.step_fn({self.r_int: -1})
+            weights.step_fn({self.r_int: -1})
 
     def test_step_fn_non_dict_input_raises_error(self):
         with self.assertRaises(TypeError):
@@ -74,14 +71,13 @@ class TestWeights(unittest.TestCase):
     def test_gaussian_width_zero_raises_error(self):
         with self.assertRaises(ValueError):
             weight_fn = weights.gaussian(0)
-            w_applied = self.apply_weight_fn(weight_fn)
+            self.apply_weight_fn(weight_fn)
 
     def test_gaussian_weight_sigma_one(self):
         weight_fn = weights.gaussian(1)
         w_applied = self.apply_weight_fn(weight_fn)
 
         actual = w_applied.loc[0]
-        actual
 
         self.assertAlmostEqual(actual, 0.6065306597)
 
@@ -93,7 +89,7 @@ class TestWeights(unittest.TestCase):
             0.88249690,
             0.99980001,
         ]
-        for sigma, expected in zip(sigma_vals, expected_vals):
+        for sigma, expected in zip(sigma_vals, expected_vals, strict=False):
             weight_fn = weights.gaussian(sigma)
             w_applied = self.apply_weight_fn(weight_fn)
             print(w_applied.loc[0])

--- a/access/tests/util.py
+++ b/access/tests/util.py
@@ -1,9 +1,8 @@
 import math
 import random
 
-import numpy as np
-import pandas as pd
 import geopandas as gpd
+import pandas as pd
 
 
 def create_nxn_grid(n, buffer=0, random_values=False, seed=44):
@@ -20,7 +19,7 @@ def create_nxn_grid(n, buffer=0, random_values=False, seed=44):
     grid: nxn size grid in a GeoDataFrame with columns 'id', 'x', 'y', 'value'
     """
     rows = []
-    id = 0
+    _id = 0
     value = 1
 
     random.seed(seed)
@@ -29,8 +28,8 @@ def create_nxn_grid(n, buffer=0, random_values=False, seed=44):
         for y in range(n):
             if random_values:
                 value = random.randint(1, 200)
-            id += 1
-            rows.append({"id": id, "x": x, "y": y, "value": value})
+            _id += 1
+            rows.append({"id": _id, "x": x, "y": y, "value": value})
 
     data = pd.DataFrame(rows, columns=["id", "x", "y", "value"])
     grid = gpd.GeoDataFrame(data, geometry=gpd.points_from_xy(data.x, data.y))


### PR DESCRIPTION
* format and lint + convert to `pytest`
  * `tests/test_misc.py`
  * `tests/test_raam.py`
  * `tests/test_weighted_catchment.py`
  * `tests/test_weights.py`
  * `tests/util.py`
* xrefs
  * #65   